### PR TITLE
Add git alias to squash branch to single changeset.

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -28,6 +28,7 @@
         assume = update-index --assume-unchanged
         unassume = update-index --no-assume-unchanged
         assumed = "!git ls-files -v | grep ^h | cut -c 3-"
-        snapshot = !git stash save "snapshot: $(date)" && git stash apply "stash@{0}"
+	snapshot = !git stash save "snapshot: $(date)" && git stash apply "stash@{0}"
+	squash-branch = !git reset $(git merge-base $1 $(git rev-parse --abbrev-ref HEAD)) && git add -A && :
 [include]
         path = ~/.gituser


### PR DESCRIPTION
This is better then git rebase -i as it doens't try to rebase commit by
commit, but just create changeset against provided branch.
Usage:
git squash-branch <target-branch>