### PR TITLE
Add docker alias to run one-time command in a container.

### DIFF
--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -82,3 +82,6 @@ function GitHub()
     fi
     xdg-open $url
 }
+
+# Run one-time command from local directory with docker
+alias docker-one-time='docker run --rm -ti -w "/command" -v `pwd`:/command'


### PR DESCRIPTION
This alias mounts current directory to the container and doesn't
persist the container itself.